### PR TITLE
Docs: Removed private YouTube video on home page

### DIFF
--- a/docs/_index.yaml
+++ b/docs/_index.yaml
@@ -99,11 +99,6 @@ landing_page:
 
   - classname: devsite-landing-row-cards
     items:
-    - heading: "Federated Learning and Analytics Research Demos using TFF"
-      youtube_id: ssM0iQRR94E
-      buttons:
-      - label: "Watch the video"
-        path: https://www.youtube.com/watch?v=ssM0iQRR94E
     - heading: "Federated Learning Workshop using TensorFlow Federated"
       youtube_id: JBNas6Yd30A
       buttons:


### PR DESCRIPTION
The home page for TensorFlow Federated ([Link](https://www.tensorflow.org/federated)) contains multiple embedded YouTube videos. The first of them is currently set to 'private', which means that only explicitly invited users can watch it, which excludes the general population.

![screenshot of tensorflow federated homepage with private yt video](https://github.com/user-attachments/assets/9e1d2b81-65f0-430d-89de-e1067a50cd68)

IMHO, this makes the website look unmaintained.

Here are some suggestions to solve this issue:
1. Set the video to 'public' again (if the person managing the YouTube channel can be contacted and allows it). If the goal of setting the video to 'private' was that the video no longer appears on the YouTube channel, it can also be set to 'unlisted' instead. This means that the video is still watchable when linked to or embedded, but won't show up on the channel.
3. Delete the video card from the home page (which I have done in this PR).
4. Replace the video with another video or card.

---
PS: Usually I would have created an issue for that, but Issues seem to be disabled for this repository.
